### PR TITLE
Update: threading messagebox

### DIFF
--- a/nfc/labAttendancy.py
+++ b/nfc/labAttendancy.py
@@ -32,12 +32,17 @@ def on_connect(tag):
         id = id_data[2:13].decode("utf-8")
         print("Student Num: " + id)
         message_thread = threading.Thread(
-            target = box.changeMsg,
-            args = ("Post Success", id)
+            target = box.defaultMsg,
+            args = ("Posting...", id)
         )
+        message_thread.start()
         suc = post.postData(id)
         if suc:
-            message_thread.start()
+            success_thread = threading.Thread(
+                target = box.changeMsg,
+                args = ("Post Success", id)
+            )
+            success_thread.start()
         else:
             error_thread.start()
     return True
@@ -58,21 +63,22 @@ def main():
     def read_nfc():
         try:
             with nfc.ContactlessFrontend('usb') as clf:
-                try:
-                    while clf.connect(rdwr={
-                        'on-connect': on_connect,
-                        'on-release': on_release,
-                    }):
-                        if (running == False):
-                            # GUIが終了していた場合にread_nfc()をとめる
-                            return
-                except nfc.tag.tt3.Type3TagCommandError:
-                    # NFCが触れる時間が短かった際に発生するエラー
-                    error_thread = threading.Thread(
-                        target = box.changeMsg,
-                        args = ("【Error】","Touch it Again!")
-                    )
-                    error_thread.start()
+                while 1:
+                    try:
+                        while clf.connect(rdwr={
+                            'on-connect': on_connect,
+                            'on-release': on_release,
+                        }):
+                            if (running == False):
+                                # GUIが終了していた場合にread_nfc()をとめる
+                                return
+                    except nfc.tag.tt3.Type3TagCommandError:
+                        # NFCが触れる時間が短かった際に発生するエラー
+                        error_thread = threading.Thread(
+                            target = box.changeMsg,
+                            args = ("【Error】","Touch it Again!")
+                        )
+                        error_thread.start()
         except IOError:
             print("NFCが接続されていません")
             box.quit()

--- a/nfc/post.py
+++ b/nfc/post.py
@@ -1,0 +1,24 @@
+import requests
+import json
+
+import config
+
+# 学生証番号を config.py に指定されたURLにPOSTする
+def postData(data):
+    if(data is None):
+        print("params is empty")
+        return False
+
+    payload = {
+        "data": data
+    }
+    url = config.url
+    headers = {
+        'Content-Type': 'application/json'
+    }
+    response = requests.post(url, data=json.dumps(payload), headers=headers)
+    if(response.status_code == 200 and response.text == "success"):
+        print("post success!")
+        return True
+    print(response.text)
+    return False

--- a/nfc/textbox.py
+++ b/nfc/textbox.py
@@ -27,9 +27,14 @@ class TextBox():
         self.box.mainloop()
 
     # デフォルトメッセージの表示
-    def defaultMsg(self):
-        self.label1["text"] = "Touch your Card"
-        self.label2["text"] = ""
+    def defaultMsg(self, *args):
+        # メッセージ文(1行目)
+        self.label1["text"] = str(args[0])
+        # メッセージ文(2行目)・読み取った番号を格納する想定
+        if len(args) == 2:
+            self.label2["text"] = str(args[1])
+        else:
+            self.label2["text"] = ""
         self.box.update_idletasks()
 
     # 引数に入っているメッセージを表示
@@ -43,7 +48,7 @@ class TextBox():
 
         # 1秒後にデフォルトメッセージに戻す
         time.sleep(1)
-        self.defaultMsg()
+        self.defaultMsg("Touch your card")
 
     def quit(self):
         self.box.quit()

--- a/nfc/textbox.py
+++ b/nfc/textbox.py
@@ -1,0 +1,53 @@
+from tkinter import *
+import time
+
+class TextBox():
+    def __init__(self):
+        self.box = Tk()
+        self.box.protocol("WM_DELETE_WINDOW", self.box.destroy)
+
+        # 初期表示設定
+        self.box.title(u"Lab Attendency")
+        ww=self.box.winfo_screenwidth()
+        wh=self.box.winfo_screenheight()
+        lw = 400
+        lh = 170
+        self.box.geometry(str(lw) + "x" + str(lh) + "+" + str(int(ww/2-lw/2)) + "+" + str(int(wh-lh)))
+        self.text = StringVar()
+        self.label1 = Label(self.box, text = "Touch your Card", font = ("Arial",30))
+        self.label1.pack()
+        self.label2 = Label(self.box, text = "", font = ("Arial",20))
+        self.label2.pack()
+
+        self.box.update_idletasks()
+
+    # メッセージボックスの作成、無限ループ
+    def start(self, thread):
+        self.box.after(100, thread)
+        self.box.mainloop()
+
+    # デフォルトメッセージの表示
+    def defaultMsg(self):
+        self.label1["text"] = "Touch your Card"
+        self.label2["text"] = ""
+        self.box.update_idletasks()
+
+    # 引数に入っているメッセージを表示
+    def changeMsg(self, *args):
+        # メッセージ文(1行目)
+        self.label1["text"] = str(args[0])
+        # メッセージ文(2行目)・読み取った番号を格納する想定
+        if len(args) == 2:
+            self.label2["text"] = str(args[1])
+        self.box.update_idletasks()
+
+        # 1秒後にデフォルトメッセージに戻す
+        time.sleep(1)
+        self.defaultMsg()
+
+    def quit(self):
+        self.box.quit()
+
+    def destroy(self):
+        self.box.destroy()
+


### PR DESCRIPTION
メッセージボックスをいちいち作ると処理が遅いので常駐化
読み取った後でもすぐに次のNFCを読み取ることができる。

ただしpost処理を挟むのでこれが終わるまでは次の読み取りはできない。
爆速で読みたいのならばpost処理もスレッド化してほしい

Close #9 
Close #12 